### PR TITLE
Fix dark mode text colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
                  optionsHtml = currentQuestion.options.map((option, index) => {
                     const isChecked = userSelections[currentQuestionIndex].includes(option.charAt(0));
                     return `
-                        <label class="option-btn flex items-center w-full text-left p-4 bg-white border-2 border-gray-200 rounded-lg hover:border-blue-400 focus:outline-none cursor-pointer">
+                        <label class="option-btn flex items-center w-full text-left p-4 bg-white border-2 border-gray-200 rounded-lg hover:border-blue-400 focus:outline-none cursor-pointer dark:bg-gray-700 dark:border-gray-500 dark:text-gray-100">
                             <input type="checkbox" class="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 mr-4" data-option-char="${option.charAt(0)}" ${isChecked ? 'checked' : ''}>
                             <span>${option}</span>
                         </label>
@@ -255,7 +255,7 @@
                  }).join('');
             } else {
                  optionsHtml = currentQuestion.options.map((option, index) => `
-                    <button class="option-btn w-full text-left p-4 bg-white border-2 border-gray-200 rounded-lg hover:border-blue-400 focus:outline-none" data-option-index="${index}">
+                    <button class="option-btn w-full text-left p-4 bg-white border-2 border-gray-200 rounded-lg hover:border-blue-400 focus:outline-none dark:bg-gray-700 dark:border-gray-500 dark:text-gray-100" data-option-index="${index}">
                         ${option}
                     </button>
                 `).join('');
@@ -265,7 +265,7 @@
 
             quizBody.innerHTML = `
                 <div class="mb-4 flex justify-between items-start">
-                    <p class="text-lg font-semibold text-gray-700 mr-4">${currentQuestion.question.replace(/\n/g, '<br>')}</p>
+                    <p class="text-lg font-semibold text-gray-700 mr-4 dark:text-gray-100">${currentQuestion.question.replace(/\n/g, '<br>')}</p>
                     <button id="flag-btn" class="text-xl">${flagIcon}</button>
                 </div>
                 <div id="options-container" class="space-y-3">
@@ -386,14 +386,14 @@
             const flaggedItems = quizData.slice(0, halfIndex).map((q, i) => {
                 if (!flaggedQuestions[i]) return '';
                 return `
-                    <div class="p-3 bg-white rounded-lg border flex justify-between items-center">
-                        <p class="text-gray-800 truncate">Question ${i + 1}: ${q.question.replace(/\n/g, ' ')}</p>
-                        <button class="review-question-btn text-sm text-blue-600 hover:underline" data-question-index="${i}">Review</button>
+                    <div class="p-3 bg-white rounded-lg border flex justify-between items-center dark:bg-gray-700 dark:border-gray-500">
+                        <p class="text-gray-800 truncate dark:text-gray-100">Question ${i + 1}: ${q.question.replace(/\n/g, ' ')}</p>
+                        <button class="review-question-btn text-sm text-blue-600 hover:underline dark:text-blue-400" data-question-index="${i}">Review</button>
                     </div>
                 `;
             }).join('');
 
-            flaggedList.innerHTML = flaggedItems || '<p class="text-center text-gray-600">No flagged questions.</p>';
+            flaggedList.innerHTML = flaggedItems || '<p class="text-center text-gray-600 dark:text-gray-300">No flagged questions.</p>';
 
             document.querySelectorAll('.review-question-btn').forEach(btn => {
                 btn.addEventListener('click', (e) => {
@@ -482,12 +482,12 @@
                 const resultIcon = isCorrect ? '✔' : '✖';
                 
                 return `
-                    <div class="p-3 bg-white rounded-lg border flex justify-between items-center">
+                    <div class="p-3 bg-white rounded-lg border flex justify-between items-center dark:bg-gray-700 dark:border-gray-500">
                         <div class="flex items-center overflow-hidden">
                            <span class="font-bold ${resultClass} mr-3">${resultIcon}</span>
-                           <p class="text-gray-800 truncate">Question ${i + 1}: ${q.question.replace(/\n/g, ' ')}</p>
+                           <p class="text-gray-800 truncate dark:text-gray-100">Question ${i + 1}: ${q.question.replace(/\n/g, ' ')}</p>
                         </div>
-                        <button class="view-rationale-btn text-sm text-blue-600 hover:underline flex-shrink-0 ml-4" data-question-index="${i}">View Details</button>
+                        <button class="view-rationale-btn text-sm text-blue-600 hover:underline flex-shrink-0 ml-4 dark:text-blue-400" data-question-index="${i}">View Details</button>
                     </div>
                 `;
             }).join('');
@@ -507,7 +507,7 @@
             const optionsContainer = document.getElementById('modal-options');
             optionsContainer.innerHTML = questionData.options.map(opt => {
                 const optLetter = opt.charAt(0);
-                let classes = 'p-3 border rounded-lg';
+                let classes = 'p-3 border rounded-lg dark:bg-gray-700 dark:border-gray-500 dark:text-gray-100';
                 let isUserAnswer = false;
                 
                 if (questionData.type === 'multi-select') {
@@ -521,7 +521,7 @@
                 } else if (isUserAnswer) {
                     classes += ' incorrect';
                 } else {
-                    classes += ' bg-gray-50';
+                    classes += ' bg-gray-50 dark:bg-gray-600';
                 }
                 return `<div class="${classes}">${opt}</div>`;
             }).join('');


### PR DESCRIPTION
## Summary
- update dynamic option markup to support dark mode
- adjust review and results listings for dark style
- ensure modal details use dark color classes

## Testing
- `htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_b_684409537b908332ac7b3ef853af66ff